### PR TITLE
Generalization queries with generalizing to lists given from passive constraint acquisition system

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -447,6 +447,7 @@ def compute_sample_weights(Y):
 class Metrics:
 
     def __init__(self):
+        self.gen_queries_count = 0
         self.queries_count = 0
         self.top_lvl_queries = 0
         self.generated_queries = 0
@@ -460,6 +461,9 @@ class Metrics:
         self.generation_time = 0
 
         self.converged = 1
+
+    def increase_gen_queries_count(self, amount=1):
+        self.gen_queries_count += amount
 
     def increase_queries_count(self, amount=1):
         self.queries_count += amount


### PR DESCRIPTION
Main changes:

1. get 2 input biases:
- 1 normal, with fixed arity constraints
- 1 with lists of cosntraints from the patterns detected through passive constraint acquisition (e.g. list of != constraints from an alldifferent detected)
2. Handle the 2 biases differently:
- When removing constraints, special handling of the lists bias: flatten the list to fixed-arity bias if a constraint included is removed
- In the objective function of PQ-Gen, handle the lists detected from patterns as "constraints likely to exist in the problem" and the fixed arity ones as "constraints likely to not exist"
3. Implementation of generalization queries for this approach:
- specific implementation for getting as input the lists from passive acquisition, not general implementation of generalization queries
- From GENACQ [1], we skip lines until line 9, as these lines construct the list "Table" which contains the possible generalizations for the given constraint (based on the types given for the problem), while here we assume that the possible generalizations are given from passive acquisition.
- If (when) we need to have normal generalization queries, we will need to implement a separate genacq function, that gets as input also types of variables given, and constructs the "table" with possible generalizations.
- One additional difference is that when a generalization query is answered negatively, we remove the list from possible generalization and we flatten it to fixed arity bias.
- Finally, we do not have a cutoff for negative answers as in [1]

Note: Changes only implemented for MQuAcq2! If we want to use also another algorithm (E.g. GrowAcq), we need to also do the respective changes there too.

[1] Bessiere, Christian, et al. "Boosting Constraint Acquisition via Generalization Queries." ECAI. 2014.